### PR TITLE
chore/deps: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 
 [dependencies]
-mio = { git = "https://github.com/carllerche/mio", branch = "net-reorg" }
+mio = "0.6.9"
 bytes = "0.4"
 rand = "0.3"
-slab = { git = "https://github.com/carllerche/slab", branch = "rewrite" }
+slab = "0.4.0"
 byteorder = "1.0"
 log = "0.3.7"
 


### PR DESCRIPTION
Point to versions of crates published on crates.io rather than to github.