### PR TITLE
Fix zero-byte writes.

### DIFF
--- a/src/out_queue.rs
+++ b/src/out_queue.rs
@@ -373,6 +373,10 @@ impl OutQueue {
             src = &src[packet_len..];
         }
 
+        if len == 0 {
+            return Err(io::ErrorKind::WouldBlock.into());
+        }
+
         Ok(len)
     }
 
@@ -388,7 +392,7 @@ impl OutQueue {
     }
 
     pub fn is_writable(&self) -> bool {
-        self.remaining_capacity() > 0
+        self.remaining_capacity() > HEADER_LEN
     }
 
     fn in_flight(&self) -> usize {


### PR DESCRIPTION
It was possible for the `UtpSocket::write` to return `Ok(0)` if it had less than HEADER_LEN bytes of capacity left in its out-buffer. Return EWOULDBLOCK in this case instead.